### PR TITLE
chore: refactor onboarding_step enum to int rank

### DIFF
--- a/components/ProtectedRoute.tsx
+++ b/components/ProtectedRoute.tsx
@@ -1,21 +1,21 @@
 import { useEffect } from "react";
 import PropTypes from "prop-types";
 import { useRouter } from "next/router";
-
 import useSupabase from "../hooks/useSupabase";
 
 export default function ProtectedRoute({ children }: { children: JSX.Element }) {
-  const { user, onboardingStep } = useSupabase();
+  const { user, rank } = useSupabase();
   const router = useRouter();
   useEffect(() => {
     if (user) {
-      if (onboardingStep !== "COMPLETE" && router.pathname !== "/welcome") {
+      // Rank may be null or 0
+      if (!rank && router.pathname !== "/welcome") {
         router.replace("/welcome");
       }
     } else {
       router.replace("/login");
     }
-  }, [user, onboardingStep, router]);
+  }, [user, rank, router]);
   return user ? children : null;
 }
 

--- a/contexts/SupabaseContext.tsx
+++ b/contexts/SupabaseContext.tsx
@@ -7,12 +7,16 @@ import {
 } from "@supabase/supabase-js";
 import supabase from "../utils/supabaseClient";
 
-enum OnboardingStep {
-  REGISTERED = "REGISTERED",
-  SCREEN_1 = "SCREEN_1",
-  SCREEN_2 = "SCREEN_2",
-  COMPLETE = "COMPLETE",
-}
+// Rank breakdown:
+// 0: user exists, but hasn't completed sign-up Step 1 (this is the DB default)
+// 1: completed Step 1, now has dashboard access + can schedule 1:1 calls
+// 2, 3: in onboarding cohort
+// 4: General member
+// 5: Member++
+
+// TODO: How do we decide when to prompt to fill in more profile data? (Step 2 and beyond)
+// We could use Rank 2 for that, but we might want more data in the future
+// Should we just query the DB and check if the fields are empty?
 
 interface EmailUser extends User {
   email: string; // We know email isn't undefined
@@ -53,8 +57,8 @@ interface SupabaseContextInterface {
   user: EmailUser | GoogleUser | null;
   username: string | null;
   setUsername: (username: string) => void;
-  onboardingStep: OnboardingStep | null;
-  setOnboardingStep: (step: OnboardingStep | string) => void;
+  rank: number | null;
+  setRank: (rank: number) => void;
 }
 
 const SupabaseContext = createContext<SupabaseContextInterface | null>(null);
@@ -63,7 +67,7 @@ function SupabaseProvider({ children }: { children: ReactChild | ReactChildren }
   // Default value checks for an active session
   const [user, setUser] = useState<User | null>(supabase.auth.session()?.user ?? null);
   const [username, setUsername] = useState<string | null>(null);
-  const [onboardingStep, setOnboardingStep_] = useState<OnboardingStep | null>(null);
+  const [rank, setRank_] = useState<number | null>(null);
 
   useEffect(() => {
     const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -79,31 +83,28 @@ function SupabaseProvider({ children }: { children: ReactChild | ReactChildren }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const { data, error, status } = await supabase
           .from("profiles")
-          .select("username, onboarding_step")
+          .select("username, rank")
           .eq("id", user.id)
-          .single() as PostgrestSingleResponse<{username: string, onboarding_step: OnboardingStep}>;
+          .single() as PostgrestSingleResponse<{username: string, rank: number}>;
 
         if (error && status !== 406) {
           throw error;
         }
 
         setUsername(data?.username ?? null);
-        setOnboardingStep_(
-          (data as {onboarding_step?: OnboardingStep})?.onboarding_step
-          || "REGISTERED" as OnboardingStep,
-        );
+        setRank_((data as {rank?: number})?.rank || 0);
       }
     }
     getUserData();
   }, [user]);
 
   // Update local state and Supabase DB
-  const setOnboardingStep = async (step: OnboardingStep | string) => {
+  const setRank = async (newRank: number) => {
     if (user) {
-      setOnboardingStep_(step as OnboardingStep);
+      setRank_(newRank);
       await supabase
         .from("profiles")
-        .update({ onboarding_step: step }, { returning: "minimal" })
+        .update({ rank: newRank }, { returning: "minimal" })
         .eq("id", user.id);
     }
   };
@@ -117,8 +118,8 @@ function SupabaseProvider({ children }: { children: ReactChild | ReactChildren }
     }
   }
 
-  // If we have user, wait to load onboardingStep before rendering (this feels kinda sketchy)
-  if (user && !onboardingStep) {
+  // If we have user, wait to load rank before rendering (this feels kinda sketchy)
+  if (user && rank === null) {
     return null;
   }
 
@@ -132,8 +133,8 @@ function SupabaseProvider({ children }: { children: ReactChild | ReactChildren }
       user: typedUser,
       username,
       setUsername,
-      onboardingStep,
-      setOnboardingStep,
+      rank,
+      setRank,
     } }>
       {children}
     </SupabaseContext.Provider>

--- a/pages/welcome.tsx
+++ b/pages/welcome.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { NextPage } from "next";
 import useSupabase from "../hooks/useSupabase";
 import ProtectedRoute from "../components/ProtectedRoute";
@@ -8,14 +7,8 @@ import OnboardingComplete from "../components/onboarding/Complete";
 import { isGoogleUser } from "../contexts/SupabaseContext";
 
 const WelcomePage: NextPage = () => {
-  const { user, onboardingStep, setOnboardingStep } = useSupabase();
-
-  useEffect(() => {
-    if (onboardingStep === "REGISTERED") {
-      setOnboardingStep("SCREEN_1");
-    }
-  }, [onboardingStep, setOnboardingStep]);
-  if (!user || onboardingStep === "REGISTERED") {
+  const { user, rank, setRank } = useSupabase();
+  if (!user) {
     return null;
   }
 
@@ -23,19 +16,20 @@ const WelcomePage: NextPage = () => {
     ? [user.user_metadata.full_name, user.user_metadata.avatar_url]
     : [undefined, undefined];
 
-  if (onboardingStep === "SCREEN_1") {
+  if (!rank) { // May be null or 0
     return (
       <Step1
         email={ user.email }
         initialName={ initialName }
         initialAvatarUrl={ initialAvatarUrl }
-        nextStep={ () => setOnboardingStep("SCREEN_2") } />
+        nextStep={ () => setRank(1) } />
     );
   }
-  if (onboardingStep === "SCREEN_2") {
-    return <Step2 nextStep={ () => setOnboardingStep("COMPLETE") } />;
+  if (rank === 1) {
+    return <Step2 nextStep={ () => setRank(2) } />;
   }
-  // Else, onboardingStep === "COMPLETE"
+
+  // Else, rank >= 2
   return <OnboardingComplete />;
 };
 


### PR DESCRIPTION
### Status
**READY** -- I might branch off of this to do some more sign-up flow functionality tweaks tomorrow, but this should be good to merge

### Description
Refactoring the `onboarding_step` enum to a `rank` integer per this thread with @mdvsh: https://v1michigan.slack.com/archives/C0341U29R4H/p1647135925468739

**Open question**: How do we decide when to prompt to fill in more profile data? (`Step2` and beyond) We could use `Rank 2` for that, but we might want more data in the future. Should we just query the DB and check if the fields are empty?

Eventually, we can delete the old `onboarding_step` column, but let's wait a few days until everyone's local copies are caught up + merged.

### Steps to Test or Reproduce
```sh
git pull --prune
git checkout onboarding-step-to-rank
npm run dev
```

1. Test that sign-up + onboarding flow work as expected -- you can't visit `/profile` until you've completed `Step2`, and visiting `/welcome` after completing `Step2` redirects to `/profile` instead