### PR TITLE
Add bio and partner data sharing consent

### DIFF
--- a/components/onboarding/Step2.tsx
+++ b/components/onboarding/Step2.tsx
@@ -7,6 +7,7 @@ import {
   YearField,
   MajorsField,
   MinorsField,
+  PartnerSharingConsentField,
 } from "../profile/fields/ProfileFields";
 import ViewResume from "../profile/ViewResume";
 import { FadeAllChildren } from "../Fade";
@@ -19,6 +20,7 @@ interface FormValues {
   year: string;
   majors: string[];
   minors: string[];
+  partnerSharingConsent: boolean;
 }
 
 interface Step2Props {
@@ -46,6 +48,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
           resume: null,
           majors: [],
           minors: [],
+          partnerSharingConsent: true,
         } as FormValues }
         validate={ () => setSubmitError(null) }
         onSubmit={ async (values, { setSubmitting }) => {
@@ -79,6 +82,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
                 minors: values.minors,
               },
               linkedin: values.linkedin,
+              partner_sharing_consent: values.partnerSharingConsent,
               updated_at: new Date(),
             }, {
               returning: "minimal", // Don't return the value after inserting
@@ -107,6 +111,9 @@ const Step2 = ({ nextStep }: Step2Props) => {
 
               <MajorsField label="Major(s)" />
               <MinorsField label="Minor(s) (optional)" />
+              <PartnerSharingConsentField
+                label="To help you find your next best role, can we share your profile with select startups or other partner organizations?"
+              />
 
               <div className="pl-6 pt-4 pb-4">
                 <button

--- a/components/onboarding/Step2.tsx
+++ b/components/onboarding/Step2.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Formik, Form } from "formik";
 import useSupabase from "../../hooks/useSupabase";
 import {
+  BioField,
   LinkedInField,
   YearField,
   MajorsField,
@@ -12,6 +13,7 @@ import { FadeAllChildren } from "../Fade";
 import { EditResume } from "../profile/fields/FileFields";
 
 interface FormValues {
+  bio: string,
   resume: File | null,
   linkedin: string, // Optional
   year: string;
@@ -38,9 +40,10 @@ const Step2 = ({ nextStep }: Step2Props) => {
       </h3>
       <Formik
         initialValues={ {
-          resume: null,
-          linkedin: "",
+          bio: "",
           year: "",
+          linkedin: "",
+          resume: null,
           majors: [],
           minors: [],
         } as FormValues }
@@ -53,8 +56,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
             .storage.from("resumes").upload(
               bucketPath,
               // values.resume is not null, would've been caught by validation
-              // eslint-disable-next-line max-len
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/no-non-null-assertion
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               values.resume!,
               {
                 contentType: "application/pdf",
@@ -70,6 +72,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
           const { error } = await supabase
             .from("profiles")
             .update({
+              bio: values.bio,
               year: values.year,
               fields_of_study: {
                 majors: values.majors,
@@ -93,6 +96,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
           // Need large pb-32 to prevent FadeAllChildren from overflowing
           <Form className="mx-auto w-4/5 px-16 py-8 pb-32 space-y-8 bg-white shadow-lg rounded-md">
             <FadeAllChildren>
+              <BioField label="Bio" />
               <YearField label="School year" />
               <LinkedInField label="LinkedIn profile (optional)" />
 

--- a/components/onboarding/Step2.tsx
+++ b/components/onboarding/Step2.tsx
@@ -111,9 +111,7 @@ const Step2 = ({ nextStep }: Step2Props) => {
 
               <MajorsField label="Major(s)" />
               <MinorsField label="Minor(s) (optional)" />
-              <PartnerSharingConsentField
-                label="To help you find your next best role, can we share your profile with select startups or other partner organizations?"
-              />
+              <PartnerSharingConsentField />
 
               <div className="pl-6 pt-4 pb-4">
                 <button

--- a/components/profile/EditProfile.tsx
+++ b/components/profile/EditProfile.tsx
@@ -1,6 +1,6 @@
 import type { Profile } from "../../pages/profile/[username]";
 import {
-  AdditionalLinksField, EmailField, InterestsField, LinkedInField, MajorsField,
+  AdditionalLinksField, BioField, EmailField, InterestsField, LinkedInField, MajorsField,
   MinorsField, PhoneField, RolesField, YearField,
 } from "./fields/ProfileFields";
 
@@ -12,6 +12,7 @@ const EditProfile = ({ profile }: EditProfileProps) => (
   <div className="grid grid-cols-2 gap-x-10 gap-y-2 justify-center items-center pl-10 pr-10">
     <EmailField value={ profile.email } label="Email" />
     <PhoneField label="Phone" />
+    <BioField label="Bio" />
     <YearField label="School year" />
     <LinkedInField label="LinkedIn" />
     <AdditionalLinksField label="Additional links" />

--- a/components/profile/ViewProfile.tsx
+++ b/components/profile/ViewProfile.tsx
@@ -22,6 +22,7 @@ const ViewProfile = ({ profile }: ViewProfileProps) => (
     {/^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)$/.test(profile.website)
       ? <Link href={ profile.website }>{profile.website}</Link>
       : <p>{profile.website}</p>}
+    <p className="my-4">{profile.bio}</p>
     <p>
       Year:
       {" "}

--- a/components/profile/fields/ProfileFields.tsx
+++ b/components/profile/fields/ProfileFields.tsx
@@ -299,6 +299,17 @@ const AdditionalLinksField = ({ label }: LabelProps) => {
   );
 };
 
+const PartnerSharingConsentField = ({ label }: LabelProps) => (
+  <div className="flex">
+    <label htmlFor="additionalLinks">{label}</label>
+    <Field
+      className="mt-auto focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 rounded-md"
+      type="checkbox"
+      name="partnerSharingConsent"
+    />
+  </div>
+);
+
 export {
   NameField,
   EmailField,
@@ -312,4 +323,5 @@ export {
   BioField,
   LinkedInField,
   AdditionalLinksField,
+  PartnerSharingConsentField,
 };

--- a/components/profile/fields/ProfileFields.tsx
+++ b/components/profile/fields/ProfileFields.tsx
@@ -228,6 +228,30 @@ const InterestsField = ({ label }: LabelProps) => {
   );
 };
 
+const BioField = ({ label }: LabelProps) => {
+  const validateBio = (value: string) => {
+    if (!value) {
+      return "Please enter a short bio";
+    }
+    if (value.length > 150) {
+      return "Please enter a bio less than 150 characters";
+    }
+    return undefined;
+  };
+  return (
+    <div>
+      <label htmlFor="bio">{label}</label>
+      <Field
+        className="w-full mt-1 self-center focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+        type="text"
+        name="bio"
+        placeholder="I invented the personal computer, co-founded Apple, and had fun doing it"
+        validate={ validateBio } />
+      <ErrorMessage name="bio" component="p" className="text-red-500" />
+    </div>
+  );
+};
+
 const LinkedInField = ({ label }: LabelProps) => {
   const validateLinkedIn = (value: string) => {
     // Note that LinkedIn is optional
@@ -285,6 +309,7 @@ export {
   MinorsField,
   RolesField,
   InterestsField,
+  BioField,
   LinkedInField,
   AdditionalLinksField,
 };

--- a/components/profile/fields/ProfileFields.tsx
+++ b/components/profile/fields/ProfileFields.tsx
@@ -299,14 +299,18 @@ const AdditionalLinksField = ({ label }: LabelProps) => {
   );
 };
 
-const PartnerSharingConsentField = ({ label }: LabelProps) => (
-  <div className="flex">
-    <label htmlFor="additionalLinks">{label}</label>
+const PartnerSharingConsentField = () => (
+  <div className="flex items-center justify-center gap-x-2">
+    <label htmlFor="partnerSharingConsent">
+      To help you find your next best role, can we share your
+      profile with select startups or other partner organizations?
+    </label>
     <Field
-      className="mt-auto focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 rounded-md"
+      className="block shadow border-gray-300 rounded-md"
       type="checkbox"
       name="partnerSharingConsent"
-    />
+      id="partnerSharingConsent"
+      />
   </div>
 );
 

--- a/pages/profile/[username].tsx
+++ b/pages/profile/[username].tsx
@@ -34,10 +34,7 @@ export type Profile = {
   avatar?: File,
   resume?: File, // Not fetched if not current user
 }
-const PROFILE_COLUMNS = (isCurrentUser: boolean) => `id, email, name, ${isCurrentUser ? "phone, " : ""}year, fields_of_study, linkedin, website, roles, interests`;
-// const PROFILE_COLUMNS = (isCurrentUser: boolean) => `id, email, name, bio,
-// ${isCurrentUser ? "phone, " : ""}year,
-// fields_of_study, linkedin, website, roles, interests, partner_sharing_consent`;
+const PROFILE_COLUMNS = (isCurrentUser: boolean) => `id, email, name, bio, ${isCurrentUser ? "phone, " : ""}year, fields_of_study, linkedin, website, roles, interests, partner_sharing_consent`;
 type DBProfile = Omit<Profile, "minors" | "majors" | "partnerSharingConsent"> & {
   fields_of_study: {
     minors: string[];


### PR DESCRIPTION
### Status
**READY** -- thanks @mdvsh!
~**HOLD** -- need DB columns added so that we can test this~

### Description
Adds two new fields to `/profile` and onboarding Step 2 -- 150-character bio and checkbox to consent to them sharing their profile.

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout bio-and-partner-consent
npm run dev
```

1. Reset your rank or delete your user if you've already filled out Step 2
2. Fill out Step 2
3. Make sure that your bio now shows on `/profile`
4. Make sure that you can edit your bio from `/profile`
5. Make sure that you can view and edit your data sharing settings from `/profile` (shown in edit mode)