### PR TITLE
[sp] remove protected route for Community Slack

### DIFF
--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -6,17 +6,21 @@ import Head from "../components/Head";
 
 const SendSlack: NextPage = () => {
   const { supabase, user } = useSupabase();
-  supabase
-    .from("slack")
-    .insert({ user_id: user?.id })
-    .then(({ error }) => {
-      // following error (in the if statement) is when supabase can't add someone
-      // to the table, which is okay!! This just means they've clicked on the link
-      // before. Therefore, we ignore the error.
-      // eslint-disable-next-line no-console
-      if (error?.code !== "23505") console.log(error);
-    });
   const router = useRouter();
+
+  // only track Slack analytics if user is logged in
+  if (user) {
+    supabase
+      .from("slack")
+      .insert({ user_id: user?.id })
+      .then(({ error }) => {
+        // following error (in the if statement) is when supabase can't add someone
+        // to the table, which is okay!! This just means they've clicked on the link
+        // before. Therefore, we ignore the error.
+        // eslint-disable-next-line no-console
+        if (error?.code !== "23505") console.log(error);
+      });
+  }
 
   useEffect(() => {
     router.push(

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import useSupabase from "../hooks/useSupabase";
 import Head from "../components/Head";
-import ProtectedRoute from "../components/ProtectedRoute";
 
 const SendSlack: NextPage = () => {
   const { supabase, user } = useSupabase();
@@ -17,9 +17,12 @@ const SendSlack: NextPage = () => {
       if (error?.code !== "23505") console.log(error);
     });
   const router = useRouter();
-  router.push(
-    "https://join.slack.com/t/v1community/shared_invite/zt-1namcs482-XjoRlPYk_MQX71nCGFxjWA"
-  );
+
+  useEffect(() => {
+    router.push(
+      "https://join.slack.com/t/v1community/shared_invite/zt-1rux4efyc-STBoY07IAKYpCODM5ls5~g"
+    );
+  }, [router]);
 
   return (
     <>
@@ -28,11 +31,5 @@ const SendSlack: NextPage = () => {
     </>
   );
 };
-
-// const ProtectedSendSlack = () => (
-//   <ProtectedRoute>
-//     <SendSlack />
-//   </ProtectedRoute>
-// );
 
 export default SendSlack;

--- a/pages/community.tsx
+++ b/pages/community.tsx
@@ -28,10 +28,11 @@ const SendSlack: NextPage = () => {
     </>
   );
 };
-const ProtectedSendSlack = () => (
-  <ProtectedRoute>
-    <SendSlack />
-  </ProtectedRoute>
-);
 
-export default ProtectedSendSlack;
+// const ProtectedSendSlack = () => (
+//   <ProtectedRoute>
+//     <SendSlack />
+//   </ProtectedRoute>
+// );
+
+export default SendSlack;


### PR DESCRIPTION
Makes it so that users don't have to sign in for `v1michigan.com/community` so we have a vanity link to tell people when they're trying to join the Slack. (*FRICTIONLESS*)