### PR TITLE
Add mobile support for 400 & 500 error pages

### DIFF
--- a/components/ErrorButtons.tsx
+++ b/components/ErrorButtons.tsx
@@ -1,9 +1,9 @@
 import GoldButton from "./GoldButton";
 
 const ErrorButtons = () => (
-  <div className="flex items-center mt-8">
+  <div className="flex flex-col items-center lg:flex-row mt-12">
     <GoldButton text="Go home &rsaquo;" link="/" />
-    <span className="mr-4" />
+    <span className="mr-4 mb-4" />
     <GoldButton text="Report in Slack &rsaquo;" link="/community" />
   </div>
 );

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -21,7 +21,7 @@ export default function Custom404() {
           </InternalLink>
         </div>
         <div className="h-screen flex flex-col items-center justify-center bg-gray-800">
-          <h1 className="text-8xl font-bold text-gray-200 flex items-center">
+          <h1 className="text-4xl lg:text-8xl font-bold text-gray-200 flex items-center">
             <span>404</span>
             <span className="border-l mx-4 h-full" />
             <span className="text-gray-200 text-2xl">Page not found</span>

--- a/pages/error.tsx
+++ b/pages/error.tsx
@@ -26,7 +26,7 @@ export default function Custom500() {
           </InternalLink>
         </div>
         <div className="h-screen flex flex-col items-center justify-center bg-gray-800">
-          <h1 className="text-6xl font-bold text-gray-200 flex items-center">
+          <h1 className="text-2xl lg:text-6xl font-bold text-gray-200 flex items-center">
             Unexpected error occurred :(
           </h1>
           {msg && (


### PR DESCRIPTION
Adjusted font sizes & error button wrapping. Test all of these on mobile & desktop:
- /error
- /error?msg=User data not found
- /404

https://deploy-preview-80--v1-platform.netlify.app/