### PR TITLE
Added in code for dynamic custom routes

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -24,7 +24,7 @@ const NAVIGATION = [
   },
   {
     name: "Ship-It",
-    href: "https://lu.ma/shipit-umich",
+    href: "/ship-it",
     right: false,
   },
   // {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -12,7 +12,7 @@ interface DynamicLinkData {
 const DynamicLink: NextPage = () => {
   const router = useRouter();
 
-  const slug = router.query.slug as string;
+  const slug = router.query.slug as string[];
   const [route, setRoute] = useState<string>("");
 
   // * Todo: Need to consider if slug is an array of multiple directories
@@ -26,12 +26,12 @@ const DynamicLink: NextPage = () => {
         return;
       }
 
+      const slugRoute = slug.join("/");
+
       const { data } = await supabase
         .from<DynamicLinkData>("dynamic_links")
         .select()
-        .eq("name", slug);
-
-      console.log(data);
+        .eq("name", slugRoute);
 
       if (!data || data?.length === 0 || !data?.[0].link) {
         setRoute("404");

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,13 +1,22 @@
 import { NextPage } from "next";
-import Redirect from "../components/Redirect";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Redirect from "../components/Redirect";
 import supabase from "../utils/supabaseClient";
+
+interface DynamicLinkData {
+  name: string;
+  link: string;
+}
 
 const DynamicLink: NextPage = () => {
   const router = useRouter();
-  const { slug } = router.query;
+
+  const slug = router.query.slug as string;
   const [route, setRoute] = useState<string>("");
+
+  // * Todo: Need to consider if slug is an array of multiple directories
+  // * ie -> v1michigan.com/<name>/<name2>, currently we only support v1michigan.com/<name>
 
   useEffect(() => {
     const fetchData = async () => {
@@ -18,20 +27,21 @@ const DynamicLink: NextPage = () => {
       }
 
       const { data } = await supabase
-        .from("dynamic_links")
+        .from<DynamicLinkData>("dynamic_links")
         .select()
         .eq("name", slug);
+
+      console.log(data);
 
       if (!data || data?.length === 0 || !data?.[0].link) {
         setRoute("404");
         return;
       }
 
-      setRoute(data?.[0].link);
+      setRoute(String(data?.[0].link));
     };
 
     fetchData();
-    return () => {};
   }, [slug]);
 
   return route ? <Redirect route={route} /> : null;

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,0 +1,40 @@
+import { NextPage } from "next";
+import Redirect from "../components/Redirect";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import supabase from "../utils/supabaseClient";
+
+const DynamicLink: NextPage = () => {
+  const router = useRouter();
+  const { slug } = router.query;
+  const [route, setRoute] = useState<string>("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      // NextJS routes to an empty slug before going to slug.
+      // So we check for this condition to prevent memory leaks from the supbase fetch request.
+      if (!slug) {
+        return;
+      }
+
+      const { data } = await supabase
+        .from("dynamic_links")
+        .select()
+        .eq("name", slug);
+
+      if (!data || data?.length === 0 || !data?.[0].link) {
+        setRoute("404");
+        return;
+      }
+
+      setRoute(data?.[0].link);
+    };
+
+    fetchData();
+    return () => {};
+  }, [slug]);
+
+  return route ? <Redirect route={route} /> : null;
+};
+
+export default DynamicLink;

--- a/pages/apply.tsx
+++ b/pages/apply.tsx
@@ -1,8 +1,0 @@
-import { NextPage } from "next";
-import Redirect from "../components/Redirect";
-
-const ApplyPage: NextPage = () => (
-  <Redirect route="https://tally.so/r/nWzPpL" />
-);
-
-export default ApplyPage;

--- a/pages/join.tsx
+++ b/pages/join.tsx
@@ -1,8 +1,0 @@
-import { NextPage } from "next";
-import Redirect from "../components/Redirect";
-import SignIn from "../components/SignIn";
-import useSupabase from "../hooks/useSupabase";
-
-const JoinPage: NextPage = () => <Redirect route="https://tally.so/r/nW844N" />;
-
-export default JoinPage;

--- a/pages/team/apply.tsx
+++ b/pages/team/apply.tsx
@@ -1,8 +1,0 @@
-import { NextPage } from "next";
-import Redirect from "../../components/Redirect";
-
-const TeamApplication: NextPage = () => (
-  <Redirect route="https://tally.so/r/3X4VXj" />
-);
-
-export default TeamApplication;

--- a/pages/team/index.tsx
+++ b/pages/team/index.tsx
@@ -1,8 +1,0 @@
-import { NextPage } from "next";
-import Redirect from "../../components/Redirect";
-
-const TeamPage: NextPage = () => (
-  <Redirect route="https://v1team.notion.site/Join-the-V1-Team-45b77563d6bb44a0bd343fc73409112a" />
-);
-
-export default TeamPage;


### PR DESCRIPTION
### Status
READY

### Description
This PR adds in a new catch-all [...slug].tsx route that takes a given route to v1michigan.com and determines if we've created any name->link pairs in supabase for it. If it doesn't exist then we redirect to the 404 error page.
Given this new functionality, removed the join.tsx and apply.tsx files.
