### PR TITLE
Feat: Add startup profile tiles and industry tags

### DIFF
--- a/components/DirectoryLayout.tsx
+++ b/components/DirectoryLayout.tsx
@@ -10,7 +10,7 @@ type LayoutProps = {
 };
 
 const DirectoryLayout = (props: LayoutProps) => {
-  const { title, description: directoryDescription, link } = props;
+  const { title, description: directoryDescription, link: _ } = props;
 
   const [startups, setStartups] = useState<Startup[] | null>(null);
 
@@ -42,7 +42,7 @@ const DirectoryLayout = (props: LayoutProps) => {
       </div>
       <div className="w-full max-w-screen-2xl mt-8 grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 pt-4">
         {startups?.map((startup) => (
-          <StartupTile startup={startup} />
+          <StartupTile startup={startup} key={startup.id} />
         ))}
       </div>
     </div>

--- a/components/DirectoryLayout.tsx
+++ b/components/DirectoryLayout.tsx
@@ -16,7 +16,11 @@ const DirectoryLayout = (props: LayoutProps) => {
 
   useEffect(() => {
     const fetchStartups = async () => {
-      const { data } = await supabase.from("startups").select();
+      const { data } = await supabase
+        .from("startups")
+        // This is necessary due to Supabase's API formatting requirements.
+        // eslint-disable-next-line quotes
+        .select(`*, profiles!startups_members (username, name)`);
       setStartups(data);
     };
     fetchStartups();

--- a/components/DirectoryLayout.tsx
+++ b/components/DirectoryLayout.tsx
@@ -18,9 +18,12 @@ const DirectoryLayout = (props: LayoutProps) => {
     const fetchStartups = async () => {
       const { data } = await supabase
         .from("startups")
-        // This is necessary due to Supabase's API formatting requirements.
-        // eslint-disable-next-line quotes
-        .select(`*, profiles!startups_members (username, name)`);
+        .select(
+          // This is necessary due to Supabase's API formatting requirements.
+          // eslint-disable-next-line quotes
+          `*, profiles!startups_members (username, name), startups_members (role, headshot_src)`
+        )
+        .order("user_id", { foreignTable: "startups_members" }); // To make sure roles are applied in the right order
       setStartups(data);
     };
     fetchStartups();

--- a/components/startups/StartupProfileTile.tsx
+++ b/components/startups/StartupProfileTile.tsx
@@ -5,19 +5,13 @@ export default function StartupProfileTile({
 }: {
   startupProfile: StartupProfile;
 }) {
-  const { headshot, name, role } = startupProfile;
+  const { username, name } = startupProfile;
 
   return (
     <div className="flex flex-col items-center mr-5">
-      <img
-        className="rounded-lg"
-        height={90}
-        width={90}
-        src={headshot}
-        alt={name}
-      />
-      <h1 className="mt-1">{name}</h1>
-      <p className="text-gray-400 text-xs">{role}</p>
+      <h1 className="mt-1">{name ?? username}</h1>
+      {/* TODO(jonas): roles+images */}
+      <p className="text-gray-400 text-xs">Software Engineer</p>
     </div>
   );
 }

--- a/components/startups/StartupProfileTile.tsx
+++ b/components/startups/StartupProfileTile.tsx
@@ -1,17 +1,29 @@
-import { StartupProfile } from "../../utils/types";
+import { StartupProfile, StartupProfileMetadata } from "../../utils/types";
 
 export default function StartupProfileTile({
   startupProfile,
+  startupProfileMetadata,
 }: {
   startupProfile: StartupProfile;
+  startupProfileMetadata: StartupProfileMetadata;
 }) {
   const { username, name } = startupProfile;
+  const { role, headshot_src: headshotSrc } = startupProfileMetadata;
+
+  const anonymousPersonImage =
+    "https://www.shutterstock.com/image-vector/default-avatar-profile-icon-social-600nw-1677509740.jpg";
 
   return (
-    <div className="flex flex-col items-center mr-5">
+    <div className="flex flex-col items-center mr-5 w-36 mb-5">
+      <img
+        className="rounded-xl"
+        src={headshotSrc ?? anonymousPersonImage}
+        height={80}
+        width={80}
+        alt={`${username} headshot`}
+      />
       <h1 className="mt-1">{name ?? username}</h1>
-      {/* TODO(jonas): roles+images */}
-      <p className="text-gray-400 text-xs">Software Engineer</p>
+      <p className="text-gray-400 text-xs">{role}</p>
     </div>
   );
 }

--- a/components/startups/StartupProfileTile.tsx
+++ b/components/startups/StartupProfileTile.tsx
@@ -1,0 +1,23 @@
+import { StartupProfile } from "../../utils/types";
+
+export default function StartupProfileTile({
+  startupProfile,
+}: {
+  startupProfile: StartupProfile;
+}) {
+  const { headshot, name, role } = startupProfile;
+
+  return (
+    <div className="flex flex-col items-center mr-5">
+      <img
+        className="rounded-lg"
+        height={90}
+        width={90}
+        src={headshot}
+        alt={name}
+      />
+      <h1 className="mt-1">{name}</h1>
+      <p className="text-gray-400 text-xs">{role}</p>
+    </div>
+  );
+}

--- a/components/startups/StartupTile.tsx
+++ b/components/startups/StartupTile.tsx
@@ -7,9 +7,10 @@ import {
 } from "@heroicons/react/outline";
 import { Dialog, Transition } from "@headlessui/react";
 import { Startup } from "../../utils/types";
+import StartupProfileTile from "./StartupProfileTile";
 
 export default function StartupTile({ startup }: { startup: Startup }) {
-  const { name, description, logo, website } = startup;
+  const { name, description, logo, website, industries, members } = startup;
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -18,7 +19,11 @@ export default function StartupTile({ startup }: { startup: Startup }) {
         className="flex flex-col bg-white font-bold p-6 leading-none text-gray-800 uppercase rounded-lg shadow-lg duration-100 border border-stone-300 cursor-pointer"
         onClick={() => setDialogOpen(true)}
       >
-        <img src={logo} className="w-1/2 mx-auto rounded-lg" alt="logo" />
+        <img
+          src={logo}
+          className="w-1/2 mx-auto rounded-lg"
+          alt={`${name} logo`}
+        />
 
         <div className="mt-6 mx-auto text-center">
           <h1 className="normal-case text-xl font-semibold leading-6">
@@ -46,15 +51,8 @@ export default function StartupTile({ startup }: { startup: Startup }) {
             }}
             className="rounded-lg p-2 font-inter text-sm leading-5 tracking-normal text-left text-gray-200 flex justify-center"
           >
-            <a
-              href={website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex flex-row m-auto items-center gap-1"
-            >
-              <InformationCircleIcon className=" inline-block h-5 w-5" />
-              <p className="inline-block">See More</p>
-            </a>
+            <InformationCircleIcon className=" inline-block h-5 w-5" />
+            <p className="inline-block">See More</p>
           </button>
 
           <button
@@ -64,6 +62,8 @@ export default function StartupTile({ startup }: { startup: Startup }) {
           >
             <a
               href={website}
+              target="_blank"
+              rel="noopener noreferrer"
               className="flex flex-row m-auto items-center gap-1"
             >
               <ExternalLinkIcon className=" inline-block h-5 w-5" />
@@ -104,7 +104,11 @@ export default function StartupTile({ startup }: { startup: Startup }) {
                 <Dialog.Panel className="w-full max-w-xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
                   <div className="flex flex-col gap-y-4">
                     <div className="flex gap-x-8">
-                      <img src={logo} className="w-48 rounded-lg" alt="logo" />
+                      <img
+                        src={logo}
+                        className="w-48 rounded-lg"
+                        alt={`${name} logo`}
+                      />
                       <div className="flex flex-col gap-y-4">
                         <h1 className="text-4xl font-bold text-gray-900">
                           {name}
@@ -122,6 +126,18 @@ export default function StartupTile({ startup }: { startup: Startup }) {
                     </div>
                     <div className="mt-2">
                       <p className="text-sm text-gray-500">{description}</p>
+                      <div className="flex">
+                        {industries?.map((industry) => (
+                          <p className="text-sm my-2 mr-1 px-2 bg-slate-300 rounded-xl">
+                            {industry}
+                          </p>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex">
+                      {members?.map((member) => (
+                        <StartupProfileTile startupProfile={member} />
+                      ))}
                     </div>
                   </div>
                 </Dialog.Panel>

--- a/components/startups/StartupTile.tsx
+++ b/components/startups/StartupTile.tsx
@@ -10,7 +10,15 @@ import { Startup } from "../../utils/types";
 import StartupProfileTile from "./StartupProfileTile";
 
 export default function StartupTile({ startup }: { startup: Startup }) {
-  const { name, description, logo, website, industries, profiles } = startup;
+  const {
+    name,
+    description,
+    logo,
+    website,
+    industries,
+    profiles,
+    startups_members: profileMetadata,
+  } = startup;
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -134,9 +142,12 @@ export default function StartupTile({ startup }: { startup: Startup }) {
                         ))}
                       </div>
                     </div>
-                    <div className="flex">
-                      {profiles?.map((profile) => (
-                        <StartupProfileTile startupProfile={profile} />
+                    <div className="flex flex-wrap justify-center">
+                      {profiles?.map((profile, i) => (
+                        <StartupProfileTile
+                          startupProfile={profile}
+                          startupProfileMetadata={profileMetadata[i]}
+                        />
                       ))}
                     </div>
                   </div>

--- a/components/startups/StartupTile.tsx
+++ b/components/startups/StartupTile.tsx
@@ -10,7 +10,7 @@ import { Startup } from "../../utils/types";
 import StartupProfileTile from "./StartupProfileTile";
 
 export default function StartupTile({ startup }: { startup: Startup }) {
-  const { name, description, logo, website, industries, members } = startup;
+  const { name, description, logo, website, industries, profiles } = startup;
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -135,8 +135,8 @@ export default function StartupTile({ startup }: { startup: Startup }) {
                       </div>
                     </div>
                     <div className="flex">
-                      {members?.map((member) => (
-                        <StartupProfileTile startupProfile={member} />
+                      {profiles?.map((profile) => (
+                        <StartupProfileTile startupProfile={profile} />
                       ))}
                     </div>
                   </div>

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -3,6 +3,11 @@ export type StartupProfile = {
   username: string;
 };
 
+export type StartupProfileMetadata = {
+  role: string;
+  headshot_src: string;
+};
+
 export type Startup = {
   created_at: string;
   description: string;
@@ -10,7 +15,7 @@ export type Startup = {
   industries: string[];
   logo: string;
   name: string;
-  roles: string[];
+  startups_members: StartupProfileMetadata[];
   size: number;
   stage: string;
   tech: string[];

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,7 +1,6 @@
 export type StartupProfile = {
-  headshot: string;
-  name: string;
-  role: string;
+  name: string | null;
+  username: string;
 };
 
 export type Startup = {
@@ -16,5 +15,5 @@ export type Startup = {
   stage: string;
   tech: string[];
   website: string;
-  members: StartupProfile[];
+  profiles: StartupProfile[];
 };

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,3 +1,9 @@
+export type StartupProfile = {
+  headshot: string;
+  name: string;
+  role: string;
+};
+
 export type Startup = {
   created_at: string;
   description: string;
@@ -10,4 +16,5 @@ export type Startup = {
   stage: string;
   tech: string[];
   website: string;
+  members: StartupProfile[];
 };


### PR DESCRIPTION
### Status
**READY**

### Description
This commit adds startup member profile tiles to the /startups page. It also adds industry tags and fixes the "See More" button.

### Todos
- [x] Change Supabase schemas to reflect this change


### Deploy Notes
Needed to remove some RLS policies on the profiles table

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout feat-member-cards
npm run dev
```

### Impacted Areas in Application
* Startup tiles in the /startups page
![startups_profiles](https://github.com/V1Michigan/v1/assets/94145174/f39db15a-0b59-460e-9f26-94b924306c33)


======================