### PR TITLE
add events link to navbar

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -27,6 +27,11 @@ const NAVIGATION = [
     href: "/ship-it",
     right: false,
   },
+  {
+    name: "Events",
+    href: "/events",
+    right: false,
+  },
   // {
   //   name: "Startups",
   //   href: "/startups",


### PR DESCRIPTION
### Status
**READY**

### Description
- Added Luma page to navbar so people can find our next event easily

![2024-09-03 14 00 41](https://github.com/user-attachments/assets/fa366f71-71d2-4a4c-83f2-d3fdb42c7189)


NOTE: we should remove the events dashboard from `/dashboard` soon and instead redirect to Luma or embed it. I believe embedding requires Luma Pro :/