### PR TITLE
Enhance connection modal features

### DIFF
--- a/components/startups/StartupProfileTile.tsx
+++ b/components/startups/StartupProfileTile.tsx
@@ -65,9 +65,7 @@ export default function StartupProfileTile({
       if (response.ok) {
         setConnectDialogOpen(false);
         setConnectionSent(true);
-      } else {
-        console.error("Failed to send connection request");
-      }
+      } 
       setIsLoading(false);
     });
 

--- a/components/startups/StartupProfileTile.tsx
+++ b/components/startups/StartupProfileTile.tsx
@@ -1,11 +1,11 @@
 import { useState, Fragment, useCallback } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/solid";
+import { FaSlack, FaEnvelope } from "react-icons/fa";
 import useSupabase from "../../hooks/useSupabase";
 import supabase from "../../utils/supabaseClient";
 import { StartupProfile, StartupProfileMetadata } from "../../utils/types";
 import InternalLink from "../Link";
-import { FaSlack, FaEnvelope } from "react-icons/fa";
 
 const CONNECTION_REQUEST_URL =
   process.env.NODE_ENV === "development"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-fast-marquee": "^1.3.1",
     "react-ga4": "^1.4.1",
     "react-html-parser": "^2.0.2",
+    "react-icons": "^5.3.0",
     "react-pdf": "^5.7.1",
     "react-reveal": "^1.2.2",
     "react-scroll-parallax": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4059,6 +4059,11 @@ react-html-parser@^2.0.2:
   dependencies:
     htmlparser2 "^3.9.0"
 
+react-icons@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
+  integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
### Status
**READY**

### Description
Made changes to the startup modal to enhance it:
- Fix bug with supabase - Change the data structure. Need to have a unique connection uuid for each connection rather than using the recipient id as a primary key, because then you can't have the recipient appear multiple times. 
- Correct the messages shown when a connection succeeds or fails
- Add icons for improved UI/UX
- Make slack text blue
- Reoganize padding/margin/alignment
- Improve the text box for the email message
- Ensure v1 rank 2 members can see both the slack and the email connection feature
- Improve connection status styling

![2024-09-03 22 49 50](https://github.com/user-attachments/assets/63bc3092-451f-4d74-9c8b-871c8422a80d)



### Related PRs
List related PRs against other branches:
Startup Modal 

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


### Todos
N/A


### Deploy Notes
DB Migrations: Needed to add a new column to connections called connection_id and assign the primary key from recipient_id to it. 

### Dependencies
- ADDED  [react-icons](https://react-icons.github.io/react-icons/)

### Migrations
YES

### Steps to Test or Reproduce
