### PR TITLE
[sp] fix pointer events & logo sizing on mobile navbar

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -136,12 +136,14 @@ export default function NavbarBuilder() {
               <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
                 <InternalLink
                   href="/"
-                  className="flex-shrink-0 w-5 hover:cursor-pointer hover:opacity-75"
+                  className="flex logo-container items-center flex-shrink-0 hover:cursor-pointer hover:opacity-75"
+                  style={{ pointerEvents: "none" }}
                 >
                   <img
                     src="/v1logowhite.svg"
                     alt="V1 logo"
-                    className="h-full"
+                    className="h-8"
+                    style={{ pointerEvents: "auto" }}
                   />
                 </InternalLink>
                 <div className="hidden sm:block sm:ml-6 w-full">


### PR DESCRIPTION
Fixed the mobile navigation menu so items are clickable.

Before:
![image](https://github.com/user-attachments/assets/41506e3f-3493-48fa-ad36-06d9796bf127)

After:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/8fbce79f-d431-4ef1-b97e-39dc39aeb35d" />
